### PR TITLE
fix: accessibility

### DIFF
--- a/docs/.vuepress/theme/components/Feedback.vue
+++ b/docs/.vuepress/theme/components/Feedback.vue
@@ -89,7 +89,7 @@ export default {
     },
     thanksTxt: {
       type: String,
-      default: 'Thank you for the feedback!'
+      default: 'Thanks! We will use your feedback to prioritize future work.'
     },
     evtYes: {
       type: String,

--- a/docs/.vuepress/theme/styles/buttons.styl
+++ b/docs/.vuepress/theme/styles/buttons.styl
@@ -11,10 +11,10 @@
 }
 
 .btn-primary {
-	background-color: $secondaryColor;
+	background-color: $primaryColor;
 	color: white;
 
 	&:hover {
-		background-color: $primaryColor;
+		background-color: $secondaryColor;
 	}
 }

--- a/docs/.vuepress/theme/styles/index.styl
+++ b/docs/.vuepress/theme/styles/index.styl
@@ -186,12 +186,6 @@ h4 {
   }
 }
 
-.content-footer {
-	a {
-		color: $secondaryColor;
-	}
-}
-
 .page-edit {
 	font-family: 'VT323', monospace;
 	font-size: 1.25rem;

--- a/docs/.vuepress/theme/styles/palette.styl
+++ b/docs/.vuepress/theme/styles/palette.styl
@@ -16,7 +16,7 @@ $primaryColor = #281857;
 $secondaryColor = #fb0d41;
 $tertiaryColor = #0dccf1;
 $accentTextColor = #3f298f;
-$linkColor = $secondaryColor;
+$linkColor = #612EA8;
 $reverseTextColor = #140d2e;
 $offWhiteColor = #f9ffff;
 


### PR DESCRIPTION
Ran the site as it exists as of 21:36 UTC 21 May 2021 through https://wave.webaim.org/ and adjusted text for contrast accordingly.

Closes #15 - see additional notes from WAVE audit there for posterity.