### PR TITLE
feat: convert remaining TK pages to "under construction" pages

### DIFF
--- a/docs/concepts/content-addressing.md
+++ b/docs/concepts/content-addressing.md
@@ -1,7 +1,8 @@
 ---
-title: Content addressing
+title: Content addressing 🚧
 description: Understand how content addressing is key to NFT best practices in this developer-focused guide.
+issueUrl: https://github.com/protocol/nft-website/issues/23
 ---
  # Content addressing
 
-Content TK
+<ContentStatus />

--- a/docs/concepts/content-persistence.md
+++ b/docs/concepts/content-persistence.md
@@ -1,13 +1,9 @@
 ---
-title: Content persistence
+title: Content persistence 🚧
 description: Learn the basics of content persistence and how decentralized storage and pinning services fit into the NFT developer lifecycle.
+issueUrl: https://github.com/protocol/nft-website/issues/24
 ---
  # Content persistence
 
-(Excerpt from main outline to be used for generating content)
-## Decentralized storage networks
-
-## Pinning services
-
-## Cloud storage
+<ContentStatus />
 

--- a/docs/how-to/creating-nfts.md
+++ b/docs/how-to/creating-nfts.md
@@ -1,17 +1,9 @@
 ---
-title: Creating NFTs
+title: Creating NFTs 🚧
 description: Learn the basics of creating NFTs in this developer-focused guide, including minting best practices and how to store NFTs persistently.
+issueUrl: https://github.com/protocol/nft-website/issues/43
 ---
  # Creating NFTs
 
-(Excerpt from main outline to be used for generating content)
-## Storing NFTs persistently
-
-## Minting on-chain
-This section might not be included in MVP.
-
-## Lazy minting
-This section might not be included in MVP.
-
-## Metadata/deterministic JSON
+<ContentStatus />
 

--- a/docs/reference/metadata-schemas.md
+++ b/docs/reference/metadata-schemas.md
@@ -1,7 +1,8 @@
 ---
-title: Metadata schemas
+title: Metadata schemas 🚧
 description: A helpful, handy guide to metadata schemas for NFT developers.
+issueUrl: https://github.com/protocol/nft-website/issues/44
 ---
  # Metadata schemas
 
-Content TK
+<ContentStatus />

--- a/docs/reference/nft-marketplaces.md
+++ b/docs/reference/nft-marketplaces.md
@@ -1,9 +1,8 @@
 ---
-title: NFT marketplaces
+title: NFT marketplaces 🚧
 description: A developer-focused guide to NFT marketplaces following best practices.
+issueUrl: https://github.com/protocol/nft-website/issues/45
 ---
  # NFT marketplaces
 
-(Excerpt from main outline to be used for generating content)
-## Marketplaces following best practices
-Check out this chart for a guide to NFT marketplaces that are following best practices.
+<ContentStatus />

--- a/docs/tutorial/end-to-end-experience.md
+++ b/docs/tutorial/end-to-end-experience.md
@@ -1,16 +1,10 @@
 ---
-title: End-to-end experience
+title: End-to-end experience 🚧
 description: Understand the end-to-end experience of storing and using NFTs in this developer-focused guide.
+issueUrl: https://github.com/protocol/nft-website/issues/39
 ---
  # End-to-end experience
 
-(Excerpt from main outline to be used for generating content)
-
-## With nft.storage
-
-### In browser
-
-## Manually
-This section might not be included in MVP.
+<ContentStatus />
 
 

--- a/docs/tutorial/gallery-app.md
+++ b/docs/tutorial/gallery-app.md
@@ -1,7 +1,8 @@
 ---
-title: Building a gallery app
+title: Building a gallery app 🚧
 description: Get a step-by-step overview of building an NFT gallery app in this developer-focused guide.
+issueUrl: https://github.com/protocol/nft-website/issues/42
 ---
  # Building a gallery app
 
-Content TK
+<ContentStatus />


### PR DESCRIPTION
This PR converts the remaining "content to come" pages to "under construction" pages for cleanliness in setting up DNS go-live.

Note that we're still intending for a few more content items to be complete prior to 28 May. Anyone curious can track progress in the project board: https://github.com/protocol/nft-website/projects/1