### PR TITLE
add basic schema reference & assorted links

### DIFF
--- a/docs/reference/metadata-schemas.md
+++ b/docs/reference/metadata-schemas.md
@@ -1,13 +1,12 @@
 ---
-title: Metadata schemas 🚧
+title: Metadata schemas
 description: A helpful, handy guide to metadata schemas for NFT developers.
-issueUrl: https://github.com/protocol/nft-website/issues/44
 ---
  # Metadata schemas
 
-This page aims to be a comprehensive guide to the metadata schemas and "best practices" used in various NFT platforms and use cases.
+This page aims to be a comprehensive guide to the metadata schemas and best practices used in various NFT platforms and use cases.
 
-We're still developing this page, so we're not quite as comprehensive as we'd like yet. Please [check the status of this page](https://github.com/protocol/nft-website/issues/44) and suggest improvements!
+**We're still developing this page, so we're not quite as comprehensive as we'd like yet. Please [check the status of this page](https://github.com/protocol/nft-website/issues/44) and suggest improvements!**
 
 ## Ethereum and EVM-compatible chains
 
@@ -39,11 +38,11 @@ NFTs grew out of the Ethereum community, and the [ERC-721](https://eips.ethereum
 
 This schema is deliberately minimal, and does not cover everything that you might want to put in your NFT metadata. However, because it's a convenient baseline, the ERC-721 schema has been widely adopted and extended by many marketplaces and NFT smart contracts.
 
-Many ERC-721 compatible contracts have adopted the [OpenSea metadata recommendations](https://docs.opensea.io/docs/metadata-standards), which suggests conventions for some additional fields that are broadly useful for common types of NFTs.
+Many ERC-721 compatible contracts have adopted the [OpenSea metadata recommendations](https://docs.opensea.io/docs/metadata-standards), which suggest conventions for additional fields that are broadly useful for common types of NFTs.
 
 ### ERC-1155
 
-The [ERC-1155](https://eips.ethereum.org/EIPS/eip-1155) "Multi-token standard" extends ERC-721 to support issuing many different types of token from the same smart contract. This allows more efficient creation of distinct token types, which has helped make NFTs practical for gaming use cases.
+The [ERC-1155](https://eips.ethereum.org/EIPS/eip-1155) multi-token standard extends ERC-721 to support issuing many types of token from the same smart contract. This allows for more efficient creation of distinct token types, which has helped make NFTs practical for gaming use cases.
 
 The ERC-1155 metadata schema is very similar to the one proposed in ERC-721. Since it only adds a few additional properties, tools supporting ERC-721 should support ERC-1155 metadata as well, though they may ignore the extra fields.
 

--- a/docs/reference/metadata-schemas.md
+++ b/docs/reference/metadata-schemas.md
@@ -5,4 +5,77 @@ issueUrl: https://github.com/protocol/nft-website/issues/44
 ---
  # Metadata schemas
 
-<ContentStatus />
+This page aims to be a comprehensive guide to the metadata schemas and "best practices" used in various NFT platforms and use cases.
+
+We're still developing this page, so we're not quite as comprehensive as we'd like yet. Please [check the status of this page](https://github.com/protocol/nft-website/issues/44) and suggest improvements!
+
+## Ethereum and EVM-compatible chains
+
+### ERC-721
+
+NFTs grew out of the Ethereum community, and the [ERC-721](https://eips.ethereum.org/EIPS/eip-721) proposal was the first formal standard for interoperable NFTs to be widely adopted. Most of the standard is devoted to the smart contract interface that an ERC-721 token must adopt, but there's also a recommendation for a baseline metadata schema:
+
+
+```json
+{
+    "title": "Asset Metadata",
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "description": "Identifies the asset to which this NFT represents"
+        },
+        "description": {
+            "type": "string",
+            "description": "Describes the asset to which this NFT represents"
+        },
+        "image": {
+            "type": "string",
+            "description": "A URI pointing to a resource with mime type image/* representing the asset to which this NFT represents. Consider making any images at a width between 320 and 1080 pixels and aspect ratio between 1.91:1 and 4:5 inclusive."
+        }
+    }
+}
+```
+
+This schema is deliberately minimal, and does not cover everything that you might want to put in your NFT metadata. However, because it's a convenient baseline, the ERC-721 schema has been widely adopted and extended by many marketplaces and NFT smart contracts.
+
+Many ERC-721 compatible contracts have adopted the [OpenSea metadata recommendations](https://docs.opensea.io/docs/metadata-standards), which suggests conventions for some additional fields that are broadly useful for common types of NFTs.
+
+### ERC-1155
+
+The [ERC-1155](https://eips.ethereum.org/EIPS/eip-1155) "Multi-token standard" extends ERC-721 to support issuing many different types of token from the same smart contract. This allows more efficient creation of distinct token types, which has helped make NFTs practical for gaming use cases.
+
+The ERC-1155 metadata schema is very similar to the one proposed in ERC-721. Since it only adds a few additional properties, tools supporting ERC-721 should support ERC-1155 metadata as well, though they may ignore the extra fields.
+
+```json
+{
+    "title": "Token Metadata",
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "description": "Identifies the asset to which this token represents"
+        },
+        "decimals": {
+            "type": "integer",
+            "description": "The number of decimal places that the token amount should display - e.g. 18, means to divide the token amount by 1000000000000000000 to get its user representation."
+        },
+        "description": {
+            "type": "string",
+            "description": "Describes the asset to which this token represents"
+        },
+        "image": {
+            "type": "string",
+            "description": "A URI pointing to a resource with mime type image/* representing the asset to which this token represents. Consider making any images at a width between 320 and 1080 pixels and aspect ratio between 1.91:1 and 4:5 inclusive."
+        },
+        "properties": {
+            "type": "object",
+            "description": "Arbitrary properties. Values may be strings, numbers, object or arrays."
+        }
+    }
+}
+```
+
+The most generally useful field is the `properties` object, which allows you to extend the schema with your own arbitrary properties without adding fields to the top-level namespace.
+
+The other additional field, `decimals`, allows ERC-1155 tokens to be either fungible or non-fungible, depending on the developer's needs. For fungible tokens, you can set use the `decimals` field to indicate how to display the quantity of a fungible token in a user interface.

--- a/docs/reference/nft-marketplaces.md
+++ b/docs/reference/nft-marketplaces.md
@@ -1,11 +1,12 @@
 ---
-title: NFT marketplaces 🚧
+title: NFT marketplaces
 description: A developer-focused guide to NFT marketplaces following best practices.
-issueUrl: https://github.com/protocol/nft-website/issues/45
 ---
  # NFT marketplaces
 
-While we're working on this page, here are some links to the some of the most active NFT marketplaces today.
+ This page aims to be a guide to NFT marketplaces that make use of the best practices we've outlined on NFT School.
+
+**We're still working on this content, so in the meantime, here are links to some of the most active NFT marketplaces today. Please [check the status of this page](https://github.com/protocol/nft-website/issues/45) and suggest improvements!**
 
 ### Visual artwork
 
@@ -28,5 +29,3 @@ While we're working on this page, here are some links to the some of the most ac
 
 - [Enjin Marketplace](https://enjin.io/software/marketplace)
 - [Hoard Exchange](https://hoard.exchange/)
-
-<ContentStatus />

--- a/docs/reference/nft-marketplaces.md
+++ b/docs/reference/nft-marketplaces.md
@@ -5,4 +5,28 @@ issueUrl: https://github.com/protocol/nft-website/issues/45
 ---
  # NFT marketplaces
 
+While we're working on this page, here are some links to the some of most active NFT marketplaces today.
+
+### Visual artwork
+
+- [OpenSea](https://opensea.io/)
+- [Rarible](https://rarible.com/)
+- [Nifty Gateway](https://niftygateway.com/)
+- [SuperRare](https://superrare.co/)
+- [Foundation](https://foundation.app/)
+
+### Music
+
+- [Rocki](https://www.rocki.app/)
+
+### Collectibles
+
+- [NBA Top Shot](https://nbatopshot.com/)
+- [Myth Market](https://myth.market/)
+
+### Game assets
+
+- [Enjin Marketplace](https://enjin.io/software/marketplace)
+- [Hoard Exchange](https://hoard.exchange/)
+
 <ContentStatus />

--- a/docs/reference/nft-marketplaces.md
+++ b/docs/reference/nft-marketplaces.md
@@ -5,7 +5,7 @@ issueUrl: https://github.com/protocol/nft-website/issues/45
 ---
  # NFT marketplaces
 
-While we're working on this page, here are some links to the some of most active NFT marketplaces today.
+While we're working on this page, here are some links to the some of the most active NFT marketplaces today.
 
 ### Visual artwork
 


### PR DESCRIPTION
This adds a little content to the metadata schemas page, covering ERC-721 and ERC-1155 and linking to the OpenSea metadata recommendations.

I also tossed a few links into the Marketplaces page. I've got a few other links to random example projects and blog posts that I'm still sorting through to see if & where they fit on the site. I'll make a new PR for those in a bit.

