### PR TITLE
fix: word breaks in code markup

### DIFF
--- a/docs/.vuepress/theme/styles/index.styl
+++ b/docs/.vuepress/theme/styles/index.styl
@@ -80,6 +80,10 @@ a {
 	color: $linkColor;
 }
 
+code {
+	word-break: break-word;
+}
+
 svg.icon.outbound {
 	color: $linkColor;
 }


### PR DESCRIPTION
Adds `word-break: break-word;` for `<code>` markup.

Closes https://github.com/protocol/nft-website/issues/82.