### PR TITLE
add context to metadata schemas page

### DIFF
--- a/docs/reference/metadata-schemas.md
+++ b/docs/reference/metadata-schemas.md
@@ -4,13 +4,13 @@ description: A helpful, handy guide to metadata schemas for NFT developers.
 ---
  # Metadata schemas
 
-As described in [NFT Basics](/concepts/non-fungible-tokens.md), an NFT is a digital asset that can be bought and sold on a blockchain network. The value of an NFT is based on what it represents, for example an image, video, or game asset. In order to make an NFT represent something, we use _metadata_.
+As described in the [NFT basics concept guide](/concepts/non-fungible-tokens.md), an NFT is a digital asset that can be bought and sold on a blockchain network. The value of an NFT is based on what it _represents_ — for example, an image, video, or game asset. To make an NFT represent something, we use _metadata_.
 
-Metadata describes the essential properties of an NFT, including its name, description, and anything else the NFT creator feels is important. In many cases, the metadata also contains links to the images and other "primary" digital assets that give an NFT its value.
+[Metadata](https://wikipedia.org/wiki/Metadata) is data that provides information about other data; in the case of an NFT, it describes that NFT's essential properties, including its name, description, and anything else its creator feels is important. In many cases, an NFT's metadata also contains links to the images and other "primary" digital assets that give an NFT its value.
 
-[NFT Marketplaces](/reference/nft-marketplaces.md) leverage metadata to display NFTs to buyers and sellers, but in order to do so, the metadata needs to be in a format that the marketplace can understand. To make your NFTs compatible with the ecosystem of marketplaces, wallets, and other NFT tooling, you should adopt an existing metadata standard, possibly extending it with your own specific needs.
+Because [NFT marketplaces](/reference/nft-marketplaces.md) leverage metadata to display NFTs to buyers and sellers, it's important for that metadata to be in a format that marketplaces can understand. To make your NFTs compatible with as much of the ecosystem of marketplaces, wallets, and other NFT tooling as possible, you should adopt an existing metadata standard, and if need be extend it with your specific needs.
 
-This reference guide shows some of the most common and useful metadata formats used by NFTs today. If your favorite standard isn't included, please [open an issue](https://github.com/protocol/nft-website/issues/new?assignees=&labels=need%2Ftriage&template=content-or-feature-suggestion.md&title=%5BCONTENT+REQUEST%5D+%28add+your+title+here%21%29).
+This reference guide shows some of the most common and useful metadata formats used by NFTs today. If your favorite standard isn't included, please [open an issue](https://github.com/protocol/nft-website/issues/new?assignees=&labels=need%2Ftriage&template=open-an-issue.md&title=%5BPAGE+ISSUE%5D+Metadata%20schemas).
 
 ## Intro to JSON schemas
 
@@ -18,19 +18,19 @@ The most common format for NFT metadata is [JSON](https://www.json.org/json-en.h
 
 Since JSON is a lightweight format, it doesn't impose any constraints on the structure of data within. Unlike XML, there's no built-in schema definition language that can be used to specify a particular "flavor" of JSON for a given use case.
 
-[JSON Schema](https://json-schema.org/) is a standard and set of tools that let you define schemas for JSON objects. These schemas define the names of object properties and what type of values are acceptable for each property. We'll use JSON Schema to show definitions for the most popular metadata standards. If you have trouble reading them, check out the official [JSON Schema getting started guide](https://json-schema.org/learn/getting-started-step-by-step).
+[JSON Schema](https://json-schema.org/) is a standard and a set of tools allowing you to define schemas for JSON objects. These schemas define the names of object properties, as well as what type of values are acceptable for each property. We'll use JSON Schema to show definitions for the most popular metadata standards. If you have trouble reading them, have a look at the official [JSON Schema getting-started guide](https://json-schema.org/learn/getting-started-step-by-step).
 
-## Linking to assets from NFT Metadata
+## Linking to NFT assets
 
 In our [concept guide to content addressing](/concepts/content-addressing.md), we explain how [IPFS](https://ipfs.io) helps make NFTs resilient to changes over time and protects users from NFTs that are tied to centralized servers and brittle URL conventions.
 
-When linking from your metadata to another digital asset like an image file, we recommend storing the asset on IPFS and using an IPFS URI to reference the asset. An IPFS URI is just the string `ipfs://` followed by an IPFS [CID](https://docs.ipfs.io/concepts/content-addressing/), for example: `ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi`.
+When linking from your metadata to another digital asset like an image file, we recommend storing the asset on IPFS and using an IPFS [Uniform Resource Identifier](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier) (URI) to reference the asset. An IPFS URI is just the string `ipfs://` followed by an IPFS [CID](https://docs.ipfs.io/concepts/content-addressing/), for example: `ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi`.
 
-For more information on using IPFS URIs in NFT metadata, see the [Best Practices for Storing NFT Data using IPFS](https://docs.ipfs.io/how-to/best-practices-for-nft-data/) guide on the IPFS documentation site.
+For more information on using IPFS URIs in NFT metadata, see [Best Practices for Storing NFT Data Using IPFS](https://docs.ipfs.io/how-to/best-practices-for-nft-data/) on the IPFS documentation site.
 
 ## Ethereum and EVM-compatible chains
 
-This section lists metadata standards for [Ethereum](https://ethereum.org) and compatible blockchains like the [Binance Smart Chain](https://binance.org).  
+This section lists metadata standards for [Ethereum](https://ethereum.org) and compatible blockchains such as the [Binance Smart Chain](https://binance.org).  
 
 ::: tip
 If you're using [nft.storage](https://nft.storage) to store your NFT assets, you can use the [`store` method](https://ipfs-shipyard.github.io/nft.storage/client/classes/lib.nftstorage.html#store) to add assets and metadata to IPFS in one call, with all the URIs for linked objects handled for you!

--- a/docs/reference/metadata-schemas.md
+++ b/docs/reference/metadata-schemas.md
@@ -8,7 +8,7 @@ As described in the [NFT basics concept guide](/concepts/non-fungible-tokens.md)
 
 [Metadata](https://wikipedia.org/wiki/Metadata) is data that provides information about other data; in the case of an NFT, it describes that NFT's essential properties, including its name, description, and anything else its creator feels is important. In many cases, an NFT's metadata also contains links to the images and other "primary" digital assets that give an NFT its value.
 
-Because [NFT marketplaces](/reference/nft-marketplaces.md) leverage metadata to display NFTs to buyers and sellers, it's important for that metadata to be in a format that marketplaces can understand. To make your NFTs compatible with as much of the ecosystem of marketplaces, wallets, and other NFT tooling as possible, you should adopt an existing metadata standard, and if need be extend it with your specific needs.
+Because [NFT marketplaces](/reference/nft-marketplaces.md) leverage metadata to display NFTs to buyers and sellers, it's important for that metadata to be in a format that marketplaces can understand. To make your NFTs compatible with as much of the ecosystem of marketplaces, wallets, and other NFT tooling as possible, you should adopt an existing metadata standard, and if need be, extend it with your specific needs.
 
 This reference guide shows some of the most common and useful metadata formats used by NFTs today. If your favorite standard isn't included, please [open an issue](https://github.com/protocol/nft-website/issues/new?assignees=&labels=need%2Ftriage&template=open-an-issue.md&title=%5BPAGE+ISSUE%5D+Metadata%20schemas).
 

--- a/docs/reference/metadata-schemas.md
+++ b/docs/reference/metadata-schemas.md
@@ -4,11 +4,37 @@ description: A helpful, handy guide to metadata schemas for NFT developers.
 ---
  # Metadata schemas
 
-This page aims to be a comprehensive guide to the metadata schemas and best practices used in various NFT platforms and use cases.
+As described in [NFT Basics](/concepts/non-fungible-tokens.md), an NFT is a digital asset that can be bought and sold on a blockchain network. The value of an NFT is based on what it represents, for example an image, video, or game asset. In order to make an NFT represent something, we use _metadata_.
 
-**We're still developing this page, so we're not quite as comprehensive as we'd like yet. Please [check the status of this page](https://github.com/protocol/nft-website/issues/44) and suggest improvements!**
+Metadata describes the essential properties of an NFT, including its name, description, and anything else the NFT creator feels is important. In many cases, the metadata also contains links to the images and other "primary" digital assets that give an NFT its value.
+
+[NFT Marketplaces](/reference/nft-marketplaces.md) leverage metadata to display NFTs to buyers and sellers, but in order to do so, the metadata needs to be in a format that the marketplace can understand. To make your NFTs compatible with the ecosystem of marketplaces, wallets, and other NFT tooling, you should adopt an existing metadata standard, possibly extending it with your own specific needs.
+
+This reference guide shows some of the most common and useful metadata formats used by NFTs today. If your favorite standard isn't included, please [open an issue](https://github.com/protocol/nft-website/issues/new?assignees=&labels=need%2Ftriage&template=content-or-feature-suggestion.md&title=%5BCONTENT+REQUEST%5D+%28add+your+title+here%21%29).
+
+## Intro to JSON schemas
+
+The most common format for NFT metadata is [JSON](https://www.json.org/json-en.html), the ubiquitous lightweight format first defined by the JavaScript language. 
+
+Since JSON is a lightweight format, it doesn't impose any constraints on the structure of data within. Unlike XML, there's no built-in schema definition language that can be used to specify a particular "flavor" of JSON for a given use case.
+
+[JSON Schema](https://json-schema.org/) is a standard and set of tools that let you define schemas for JSON objects. These schemas define the names of object properties and what type of values are acceptable for each property. We'll use JSON Schema to show definitions for the most popular metadata standards. If you have trouble reading them, check out the official [JSON Schema getting started guide](https://json-schema.org/learn/getting-started-step-by-step).
+
+## Linking to assets from NFT Metadata
+
+In our [concept guide to content addressing](/concepts/content-addressing.md), we explain how [IPFS](https://ipfs.io) helps make NFTs resilient to changes over time and protects users from NFTs that are tied to centralized servers and brittle URL conventions.
+
+When linking from your metadata to another digital asset like an image file, we recommend storing the asset on IPFS and using an IPFS URI to reference the asset. An IPFS URI is just the string `ipfs://` followed by an IPFS [CID](https://docs.ipfs.io/concepts/content-addressing/), for example: `ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi`.
+
+For more information on using IPFS URIs in NFT metadata, see the [Best Practices for Storing NFT Data using IPFS](https://docs.ipfs.io/how-to/best-practices-for-nft-data/) guide on the IPFS documentation site.
 
 ## Ethereum and EVM-compatible chains
+
+This section lists metadata standards for [Ethereum](https://ethereum.org) and compatible blockchains like the [Binance Smart Chain](https://binance.org).  
+
+::: tip
+If you're using [nft.storage](https://nft.storage) to store your NFT assets, you can use the [`store` method](https://ipfs-shipyard.github.io/nft.storage/client/classes/lib.nftstorage.html#store) to add assets and metadata to IPFS in one call, with all the URIs for linked objects handled for you!
+:::
 
 ### ERC-721
 


### PR DESCRIPTION
This adds an intro paragraph and some more context to the metadata schemas page, plus a link to the "best practices" doc on docs.ipfs.io. I also added a blurb about how nft.storage can handle metadata for you.

Closes #44 